### PR TITLE
Add JavaDoc rules for newer IDE codestyle file format

### DIFF
--- a/configs/codestyles/ButtonAndroid.xml
+++ b/configs/codestyles/ButtonAndroid.xml
@@ -74,6 +74,13 @@
   </AndroidXmlCodeStyleSettings>
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+    <option name="JD_P_AT_EMPTY_LINES" value="false" />
+    <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+    <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+    <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">


### PR DESCRIPTION
Newer versions of Android Studio seem to not correctly apply the rules we have for JavaDoc defined on https://github.com/button/java-code-styles

# Reason
The `keys` for this tab on the IDE have changed to live under a different place on the XML hierarchy, and Studio doesn't seem to know how to migrate these.

# Solution

Add the corresponding keys to the new expected section of XML.


# Test

1. Remove the existing code style rules from latest Android Studio Canary version
2. Quit the IDE
3. Run the `install.sh` script to apply the new rules
4. Open and validate the section for JavaDoc contains the expected selected options


Related to ticket : https://button.atlassian.net/browse/MOB-4541